### PR TITLE
Fix 'undefined or null' error when Cargo.toml contains no target section

### DIFF
--- a/src/toml/listener.ts
+++ b/src/toml/listener.ts
@@ -21,7 +21,7 @@ function parseAndDecorate(editor: TextEditor) {
   const tomlDependencies = toml["dependencies"];
 
   // parse target dependencies and add to dependencies
-  const targets = toml["target"];
+  const targets = toml["target"] || {};
   Object.keys(targets).map(key => {
     const target = targets[key];
     if (target.dependencies) {


### PR DESCRIPTION
If there is no target section, Object.keys(targets) will throw an exception, so replace it with an empty object in that case.