### PR TITLE
Avoid error on missing [dependencies] section

### DIFF
--- a/src/toml/listener.ts
+++ b/src/toml/listener.ts
@@ -19,7 +19,7 @@ function parseAndDecorate(editor: TextEditor) {
   const text = editor.document.getText();
   try {
     const toml = parse(text);
-    const tomlDependencies = toml["dependencies"];
+    const tomlDependencies = toml["dependencies"] || {};
     Object.assign(tomlDependencies, toml["dev-dependencies"]);
     Object.assign(tomlDependencies, toml["build-dependencies"]);
     // parse target dependencies and add to dependencies


### PR DESCRIPTION
Hi @serayuzgur 

I'm new to Rust and immediately liked it even more after discovering and using your `crates` extension :) I only got a bit confused about `Cargo.toml is not valid! {}` error messages when opening files like https://github.com/servo/servo/blob/master/Cargo.toml

Until I found out that it's all about the missing `[dependencies]` section, which seems to be quite usual for `Cargo.toml` files defining `[workspace]`s

So I fixed that :)