### PR TITLE
decoration(): Improve RegExp()s

### DIFF
--- a/src/toml/decorations.ts
+++ b/src/toml/decorations.ts
@@ -26,12 +26,12 @@ function decoration(
   upToDateDecorator: string,
 ): Array<DecorationOptions> {
   const isOutOfLine =
-    new RegExp(`.*dependencies.${crate}]`, "g").exec(
+    new RegExp(`^\\s*\\[dependencies.${crate}\\]`, "gm").exec(
       editor.document.getText(),
     ) !== null;
   const regex = isOutOfLine
-    ? new RegExp(`.*dependencies.${crate}]\nversion\\\s*=.*`, "g")
-    : new RegExp(`.*${crate}\\\s*=.*`, "g");
+    ? new RegExp(`^\\s*\\[dependencies.${crate}\\]\\s*\nversion\\s*=.*`, "gm")
+    : new RegExp(`^\\s*${crate}\\s*=.*`, "gm");
   const decorations = [];
   while (true) {
     // Also handle json valued dependencies


### PR DESCRIPTION
Hi @serayuzgur ... again :) Found another little issue when working with https://github.com/paulrouget/servoshell/blob/244631ccdc4525fe15f527fd0aa246fa298b168f/Cargo.toml

It has `glutin` in `[dependencies]` and:

```toml
[features]
force-glutin = []
```

Because ```RegExp(`.*${crate}\\\s*=.*`, "g")``` does not check what actually comes before the crate name, `force-glutin` got the same decoration as `glutin`

I changed the `RegExp` to match only if nothing else than whitespace comes before the actual pattern on the same line

I also changed the `OutOfLine` patterns in the same way for consistency

To make `^` and also generally the `OutOfLine` search for `[dependencies.${create}]\nversion = ` work, multiline mode had to be enabled by adding the `m` flag

And finally I found out that the third `\` in `\\\s` is not necessary, so I simplified that