### PR TITLE
decoration(): Improve RegExp()s some more :)

### DIFF
--- a/src/toml/decorations.ts
+++ b/src/toml/decorations.ts
@@ -26,11 +26,14 @@ function decoration(
   upToDateDecorator: string,
 ): Array<DecorationOptions> {
   const isOutOfLine =
-    new RegExp(`^\\s*\\[dependencies.${crate}\\]`, "gm").exec(
+    new RegExp(`^\\s*\\[(.*\\.)?dependencies.${crate}\\]`, "gm").exec(
       editor.document.getText(),
     ) !== null;
   const regex = isOutOfLine
-    ? new RegExp(`^\\s*\\[dependencies.${crate}\\]\\s*\nversion\\s*=.*`, "gm")
+    ? new RegExp(
+      `^\\s*\\[(.*\\.)?dependencies.${crate}\\]\\s*\nversion\\s*=.*`,
+      "gm",
+    )
     : new RegExp(`^\\s*${crate}\\s*=.*`, "gm");
   const decorations = [];
   while (true) {


### PR DESCRIPTION
Oops! #18 broke the support for `OutOfLine` cases with inline parent sections before `dependencies`, like `[target.'cfg(target_os = "windows")'.dependencies.winapi]`

This fixes it :)