### PR TITLE
isWhiteSpace(): Add check for \r

### DIFF
--- a/src/toml/parser.ts
+++ b/src/toml/parser.ts
@@ -268,5 +268,5 @@ function initNewItem(item: Item, parent: Item, i: number, buff: Array<string>) {
 }
 
 function isWhiteSpace(ch: string) {
-  return ch === " " || ch === "\n" || ch === "\t";
+  return ch === " " || ch === "\n" || ch === "\r" || ch === "\t";
 }


### PR DESCRIPTION
The new integrated TOML parser doesn't work with Windows line endings, because `isWhiteSpace()` doesn't check for `\r`

Relates to https://github.com/serayuzgur/crates/issues/17