### PR TITLE
Add configurable option to suppress error toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ It is so **simple** that you do not need any configuration, but if you insist...
 
 `crates.listPreReleases` : If true, pre-release versions will be listed in hover and at decoration. Default is false.
 
+`crates.suppressErrorToasts` : If true, all error message toasts will be suppressed. Default is false.
+
 ## Known Issues
 
 - All glitches will be cleared on save.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,12 @@
           "scope": "resource",
           "default": false,
           "description": "If true, pre-release versions will be available."
+        },
+        "crates.suppressErrorToasts": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false,
+          "description": "If true, suppress all error toasts."
         }
       }
     }

--- a/src/toml/listener.ts
+++ b/src/toml/listener.ts
@@ -21,6 +21,13 @@ export interface Dependency {
 }
 
 let decoration: TextEditorDecorationType;
+let suppressErrorToasts: boolean | undefined = false;
+
+function showErrorMessage(message: string, ...items: string[]) {
+  if (!suppressErrorToasts) {
+    window.showErrorMessage(message, ...items);
+  }
+}
 
 function parseToml(text: string): Item[] {
   console.log("Parsing...");
@@ -74,7 +81,7 @@ function decorateVersions(editor: TextEditor, dependencies: Array<Dependency>) {
   });
   decoration = decorate(editor, filtered);
   if (errors.length) {
-    window.showErrorMessage(`Fetch Errors:  ${errors.join(" , ")}`, "Retry");
+    showErrorMessage(`Fetch Errors:  ${errors.join(" , ")}`, "Retry");
     statusBarItem.setText("⚠️ Completed with errors");
   } else {
     statusBarItem.setText("OK");
@@ -85,6 +92,7 @@ function parseAndDecorate(editor: TextEditor) {
   const text = editor.document.getText();
   const config = workspace.getConfiguration("", editor.document.uri);
   const shouldListPreRels = config.get("crates.listPreReleases");
+  suppressErrorToasts = config.get("crates.suppressErrorToasts");
 
   try {
     // Parse
@@ -97,7 +105,7 @@ function parseAndDecorate(editor: TextEditor) {
   } catch (e) {
     console.error(e);
     statusBarItem.setText("Cargo.toml is not valid!");
-    window.showErrorMessage(`Cargo.toml is not valid! ${JSON.stringify(e)}`);
+    showErrorMessage(`Cargo.toml is not valid! ${JSON.stringify(e)}`);
     if (decoration) {
       decoration.dispose();
     }


### PR DESCRIPTION
Hello, I am using git dependencies that have version tags (ex: `gfx-backend-vulkan = { git = "https://github.com/gfx-rs/gfx.git", branch = "master", version = "0.1" }`) and every time I open or save the file, I get an error message toast for these dependencies.

I considered two solutions, one for filtering out git dependencies, which I think was ruled out in #11 (?), and the other solution was to provide an option for users to suppress error toasts.

Having the suppress functionality enabled still shows that errors have occurred on the status bar, so users still have information on whether or not errors occurred.

I am totally open to discussing a better solution for users (including the first one I mentioned about filtering git dependencies). Let me know!