### PR TITLE
fix changing version multiple times without save

### DIFF
--- a/src/toml/commands.ts
+++ b/src/toml/commands.ts
@@ -30,6 +30,7 @@ export const replaceVersion = commands.registerTextEditorCommand(
           ),
           info.item,
         );
+        status.inProgress = false;
       }
     }
   },


### PR DESCRIPTION
This fixes #32 but I'm not entirely sure if it is a proper solution since the status.inprogress might have to stay true for longer that this, although I can't think of a reason why. (To be fair, I'm not sure if the entire inprogress check is needed at all)