### PR TITLE
Fix for #52

### DIFF
--- a/src/toml/decorations.ts
+++ b/src/toml/decorations.ts
@@ -39,7 +39,8 @@ function decoration(
   // Also handle json valued dependencies
 
   const start = item.start;
-  const end = item.end;
+  const endofline = editor.document.lineAt(editor.document.positionAt(item.end)).range.end;
+  const end = editor.document.offsetAt(endofline);
   const currentVersion = item.value;
 
   const hasLatest =


### PR DESCRIPTION
Simple fix. End now points to the end of the line instead of the end of the version string.