### PR TITLE
Toml multiline string fix

### DIFF
--- a/src/test/full.toml
+++ b/src/test/full.toml
@@ -2,7 +2,9 @@
 name = "asasas"
 version = "0.14.0"
 readme = "README.md"
-description = "This description is somewhat lengthy"
+description = """
+This description is somewhat lengthy
+"""
 
 [package.metadata.docs.rs]
 features = ["icon_loading","osman"]

--- a/src/test/full.toml
+++ b/src/test/full.toml
@@ -2,6 +2,7 @@
 name = "asasas"
 version = "0.14.0"
 readme = "README.md"
+description = "This description is somewhat lengthy"
 
 [package.metadata.docs.rs]
 features = ["icon_loading","osman"]

--- a/src/test/toml/parse.test.ts
+++ b/src/test/toml/parse.test.ts
@@ -46,13 +46,13 @@ suite("Parser Tests", function() {
     {
       const item = doc.values[0];
       const section = tomlFile.substring(item.start, item.end);
-      const desiredSection = tomlFile.substring(0, 67);
+      const desiredSection = tomlFile.substring(0, 120);
       assert.equal(section, desiredSection);
     }
     {
       const item = doc.values[doc.values.length - 1];
       const section = tomlFile.substring(item.start, item.end - 1);
-      const desiredSection = tomlFile.substring(1674, 1909);
+      const desiredSection = tomlFile.substring(1727, 1962);
       // assert.equal(section.length, desiredSection.length);
 
       assert.equal(section, desiredSection);
@@ -61,7 +61,7 @@ suite("Parser Tests", function() {
 
   test("Read Values", function() {
     const doc = parse(tomlFile);
-    const expected = [3, 1, 1, 1, 7, 2, 2, 1, 1, 1, 1, 5, 1, 2, 5, 1];
+    const expected = [4, 1, 1, 1, 7, 2, 2, 1, 1, 1, 1, 5, 1, 2, 5, 1];
 
     assert.equal(doc.values.length, expected.length);
     for (let i = 0; i < expected.length; i++) {

--- a/src/test/toml/parse.test.ts
+++ b/src/test/toml/parse.test.ts
@@ -46,13 +46,13 @@ suite("Parser Tests", function() {
     {
       const item = doc.values[0];
       const section = tomlFile.substring(item.start, item.end);
-      const desiredSection = tomlFile.substring(0, 120);
+      const desiredSection = tomlFile.substring(0, 126);
       assert.equal(section, desiredSection);
     }
     {
       const item = doc.values[doc.values.length - 1];
       const section = tomlFile.substring(item.start, item.end - 1);
-      const desiredSection = tomlFile.substring(1727, 1962);
+      const desiredSection = tomlFile.substring(1733, 1968);
       // assert.equal(section.length, desiredSection.length);
 
       assert.equal(section, desiredSection);

--- a/src/toml/parser.ts
+++ b/src/toml/parser.ts
@@ -212,12 +212,19 @@ function parseString(data: string, item: Item, index: number, opener: string): n
   let i = index;
   item.start = index;
   let buff: string[] = [];
+  let multiline = data.substring(i, i + 3) === opener.repeat(3);
+  if (multiline) {
+    i += 2;
+  }
   while (i++ < data.length) {
     const ch = data.charAt(i);
     switch (ch) {
       case '"':
       case "'":
-        if (ch === opener) {
+        if (ch === opener && (!multiline || data.substring(i, i + 3) === opener.repeat(3))) {
+          if (multiline) {
+            i += 2;
+          }
           item.value = buff.join("");
           item.end = i;
           return i;


### PR DESCRIPTION
I think this patch should fix #88. Notably this does not correctly handle the white-space trimming part of the TOML spec, but I don't think it is needed here.

Thank you so much for this awesome extension!!