### PR TITLE
Use origin/HEAD instead of origin/master

### DIFF
--- a/src/api/local_registry.ts
+++ b/src/api/local_registry.ts
@@ -38,7 +38,7 @@ export function checkCargoRegistry(localIndexHash?: string) {
 
 export const versions = (name: string) => {
   return exec(
-    `git --no-pager --git-dir="${gitDir}" show origin/master:${decidePath(name)}`,
+    `git --no-pager --git-dir="${gitDir}" show origin/HEAD:${decidePath(name)}`,
     { maxBuffer: 8 * 1024 * 1024 }  // "8M ought to be enough for anyone."
   )
     .then((buf: { stdout: Buffer, stderr: Buffer; }) => {


### PR DESCRIPTION
It seems that cargo is now using HEAD instead of master.
So, if using the local index, it is no longer possible to get the latest version of crates.

Refs: https://github.com/rust-lang/cargo/pull/9133