### PR TITLE
Fix for #122

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
         "crates.localCargoIndexBranch": {
           "type": "string",
           "scope": "resource",
-          "default": "origin/master",
+          "default": "origin/HEAD",
           "description": "The branch for crates.io index. Default value goes to origin/HEAD."
         }
       }

--- a/src/api/local_registry.ts
+++ b/src/api/local_registry.ts
@@ -26,7 +26,7 @@ function getCargoPath() {
 
 
 let gitDir = path.resolve(cargoHome, "registry/index/github.com-1ecc6299db9ec823/.git/");
-let gitBranch = "origin/master";
+let gitBranch = "origin/HEAD";
 
 
 export function checkCargoRegistry(localIndexHash?: string, localGitBranch?: string) {

--- a/src/ui/decoration.ts
+++ b/src/ui/decoration.ts
@@ -46,7 +46,19 @@ export default function decoration(
   const version = item.value?.replace(",", "");
   const [satisfies, maxSatisfying] = checkVersion(version, versions);
 
-  const hoverMessage = error ? new MarkdownString(`**${error}**`) : new MarkdownString(`#### Versions`);
+  const formatError = (error: string) => {
+    // Markdown does not like newlines in middle of emphasis, or spaces next to emphasis characters.
+    const error_parts = error.split('\n');
+    const markdown = new MarkdownString();
+    // Ignore empty strings
+    error_parts.filter(s => s).forEach(part => {
+      markdown.appendMarkdown("**");
+      markdown.appendText(part.trim()); // Gets rid of Markdown-breaking spaces, then append text safely escaped.
+      markdown.appendMarkdown("**\n\n"); // Put the newlines back
+    });
+    return markdown;
+  };
+  const hoverMessage = error ? formatError(error) : new MarkdownString(`#### Versions`);
   hoverMessage.appendMarkdown(` _( [Check Reviews](https://web.crev.dev/rust-reviews/crate/${item.key.replace(/"/g, "")}) )_`);
   hoverMessage.isTrusted = true;
 


### PR DESCRIPTION
Please review carefully, as I might have overlooked what the `error` in the hover message can be, and also my Typescript is not exactly fluent.

The changes to `decoration.ts` now process the hover message's markdown correctly for me (no more `**` at the start and before "check reviews", but actually bold text). Also text that contains backslashes is escaped correctly: eg. `users\user\.cargo` where before it would show up as `users\user.cargo` in the error message.
![hover](https://user-images.githubusercontent.com/15895604/113195310-cc7f1000-926a-11eb-9aa8-c33c4d38604c.png)

Other change is the default index branch, which I believe was correctly changed to `origin/HEAD` in #120 but then was lost somewhere along the way. (That fixes the above error for me)
