### PR TITLE
Add Quick Actions and `?` -> `<Latest Version>` interpolation!

### DIFF
--- a/src/core/listener.ts
+++ b/src/core/listener.ts
@@ -42,6 +42,7 @@ export async function parseAndDecorate(
     : undefined;
 
   try {
+    
     // Parse
     dependencies = parseToml(text);
     if (fetchDeps)
@@ -59,6 +60,7 @@ export async function parseAndDecorate(
       await quickFillDependencies(editor, dependencies, fetchedDeps);
 
     decorate(editor, fetchedDeps);
+
   } catch (e) {
     console.error(e);
     statusBarItem.setText("Cargo.toml is not valid!");

--- a/src/core/quickFill.ts
+++ b/src/core/quickFill.ts
@@ -1,0 +1,27 @@
+import { TextEditor, Range } from "vscode";
+import Dependency from "./Dependency";
+import Item from "./Item";
+
+export default async function quickFillDependencies(editor: TextEditor, dependencies: Item[], fetchedDeps: Dependency[]) {
+	if (dependencies.length === 0 || fetchedDeps.length === 0) { return; }
+	await editor.edit(edit => {
+		for (let i = 0; i < dependencies.length; i++) {
+			const dependency = dependencies[i];
+			if (dependency.value === "?") {
+				const fetchedDep = fetchedDeps[i];
+				if (!fetchedDep.versions || fetchedDep.versions?.length === 0) { return; }
+
+				// Make sure we update the value of the Dependency as well.
+				dependency.value = fetchedDep.versions[0];
+
+				edit.replace(
+					new Range(
+						editor.document.positionAt(dependency.start + 1),
+						editor.document.positionAt(dependency.end - 1)
+					),
+					fetchedDep.versions[0]
+				);
+			}
+		}
+	});
+}

--- a/src/core/quickFill.ts
+++ b/src/core/quickFill.ts
@@ -2,26 +2,30 @@ import { TextEditor, Range } from "vscode";
 import Dependency from "./Dependency";
 import Item from "./Item";
 
-export default async function quickFillDependencies(editor: TextEditor, dependencies: Item[], fetchedDeps: Dependency[]) {
-	if (dependencies.length === 0 || fetchedDeps.length === 0) { return; }
-	await editor.edit(edit => {
-		for (let i = 0; i < dependencies.length; i++) {
-			const dependency = dependencies[i];
-			if (dependency.value === "?") {
-				const fetchedDep = fetchedDeps[i];
-				if (!fetchedDep.versions || fetchedDep.versions?.length === 0) { return; }
+export default async function quickFillDependencies(
+  editor: TextEditor,
+  dependencies: Item[],
+  fetchedDeps: Dependency[]
+) {
+  if (dependencies.length === 0 || fetchedDeps.length === 0) return;
+  await editor.edit((edit) => {
+    for (let i = 0; i < dependencies.length; i++) {
+      const dependency = dependencies[i];
+      if (dependency.value === "?") {
+        const fetchedDep = fetchedDeps[i];
+        if (!fetchedDep.versions || fetchedDep.versions?.length === 0) return;
 
-				// Make sure we update the value of the Dependency as well.
-				dependency.value = fetchedDep.versions[0];
+        // Make sure we update the value of the Dependency as well.
+        dependency.value = fetchedDep.versions[0];
 
-				edit.replace(
-					new Range(
-						editor.document.positionAt(dependency.start + 1),
-						editor.document.positionAt(dependency.end - 1)
-					),
-					fetchedDep.versions[0]
-				);
-			}
-		}
-	});
+        edit.replace(
+          new Range(
+            editor.document.positionAt(dependency.start + 1),
+            editor.document.positionAt(dependency.end - 1)
+          ),
+          fetchedDep.versions[0]
+        );
+      }
+    }
+  });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,29 +8,42 @@ import {
   ExtensionContext,
   TextDocumentChangeEvent,
   TextDocument,
+  languages,
+  CodeActionKind,
 } from "vscode";
 import tomlListener from "./core/listener";
 import TomlCommands from "./toml/commands";
+import QuickActions from "./providers/quickActions";
 
 export function activate(context: ExtensionContext) {
-  // Add active text editor listener and run once on start.
-  context.subscriptions.push(window.onDidChangeActiveTextEditor(tomlListener));
-
   context.subscriptions.push(
+    // Add active text editor listener and run once on start.
+    window.onDidChangeActiveTextEditor(tomlListener),
+
     // When the text document is changed, fetch + check dependencies
-    workspace.onDidChangeTextDocument((e:TextDocumentChangeEvent) => {
+    workspace.onDidChangeTextDocument((e: TextDocumentChangeEvent) => {
       const { fileName } = e.document;
-      if (!e.document.isDirty && fileName.toLocaleLowerCase().endsWith("cargo.toml")) {
+      if (
+        !e.document.isDirty &&
+        fileName.toLocaleLowerCase().endsWith("cargo.toml")
+      ) {
         tomlListener(window.activeTextEditor);
       }
     }),
 
     // When the text document is saved, search for "?" versions and replace with the latest
-    workspace.onDidSaveTextDocument((document:TextDocument) => {
+    workspace.onDidSaveTextDocument((document: TextDocument) => {
       if (window.activeTextEditor?.document == document) {
         tomlListener(window.activeTextEditor, true);
       }
-    })
+    }),
+
+    // Register our Quick Actions provider
+    languages.registerCodeActionsProvider(
+      { language: "toml", pattern: "**/[Cc]argo.toml" },
+      new QuickActions(),
+      { providedCodeActionKinds: [CodeActionKind.QuickFix] }
+    )
   );
 
   tomlListener(window.activeTextEditor);

--- a/src/providers/quickActions.ts
+++ b/src/providers/quickActions.ts
@@ -1,0 +1,101 @@
+import {
+  CancellationToken,
+  CodeAction,
+  CodeActionContext,
+  CodeActionKind,
+  CodeActionProvider,
+  Command,
+  Range,
+  Selection,
+  TextDocument,
+  window,
+  WorkspaceEdit,
+} from "vscode";
+
+import { dependencies, fetchedDeps, parseAndDecorate } from "../core/listener";
+
+export default class QuickActions implements CodeActionProvider {
+  async provideCodeActions(
+    document: TextDocument,
+    range: Range | Selection,
+    context: CodeActionContext,
+    _token: CancellationToken
+  ): Promise<(Command | CodeAction)[] | null | undefined> {
+    if (context.only && context.only! !== CodeActionKind.QuickFix)
+      return Promise.resolve([]);
+
+    if (document.isDirty) {
+      await parseAndDecorate(window.activeTextEditor!, false, false);
+    }
+
+    if (
+      !dependencies ||
+      !fetchedDeps ||
+      dependencies.length === 0 ||
+      fetchedDeps.length === 0
+    )
+      return Promise.resolve([]);
+
+    let isSelection = !range.start.isEqual(range.end);
+
+    let lastTitle: string;
+    let edit = new WorkspaceEdit();
+    let edits = 0;
+
+    for (let i = 0; i < dependencies.length; i++) {
+      const fetchedDep = fetchedDeps[i];
+      if (!fetchedDep.versions) continue;
+
+      const dependency = dependencies[i];
+      console.log(dependency);
+
+      // Check that the cursor/selection matches the range of the TOML version string
+      const versionRange = new Range(
+        document.positionAt(dependency.start),
+        document.positionAt(dependency.end)
+      );
+      if (isSelection) {
+        if (!range.contains(versionRange)) continue;
+      } else {
+        if (!versionRange.contains(range)) continue;
+      }
+
+      // It's up to date
+      const latestVersion = fetchedDep.versions[0];
+      if (dependency.value === latestVersion) continue;
+
+      edit.replace(
+        document.uri,
+        new Range(
+          document.positionAt(dependency.start + 1),
+          document.positionAt(dependency.end - 1)
+        ),
+        latestVersion
+      );
+      edits++;
+
+      lastTitle = `Update ${dependency.key} to ${latestVersion}`;
+      console.log(lastTitle, edits);
+      if (!isSelection) break;
+    }
+
+    switch (edits) {
+      case 0:
+        return Promise.resolve([]);
+
+      case 1:
+        var codeAction = new CodeAction(lastTitle!, CodeActionKind.QuickFix);
+        codeAction.edit = edit;
+        codeAction.isPreferred = true;
+        return Promise.resolve([codeAction]);
+
+      default:
+        var codeAction = new CodeAction(
+          "Update Dependencies",
+          CodeActionKind.QuickFix
+        );
+        codeAction.edit = edit;
+        return Promise.resolve([codeAction]);
+    }
+  }
+}

--- a/src/providers/quickActions.ts
+++ b/src/providers/quickActions.ts
@@ -47,7 +47,6 @@ export default class QuickActions implements CodeActionProvider {
       if (!fetchedDep.versions) continue;
 
       const dependency = dependencies[i];
-      console.log(dependency);
 
       // Check that the cursor/selection matches the range of the TOML version string
       const versionRange = new Range(
@@ -75,7 +74,6 @@ export default class QuickActions implements CodeActionProvider {
       edits++;
 
       lastTitle = `Update ${dependency.key} to ${latestVersion}`;
-      console.log(lastTitle, edits);
       if (!isSelection) break;
     }
 

--- a/src/providers/quickActions.ts
+++ b/src/providers/quickActions.ts
@@ -13,6 +13,7 @@ import {
 } from "vscode";
 
 import { dependencies, fetchedDeps, parseAndDecorate } from "../core/listener";
+import { checkVersion } from "../semver/semverUtils";
 
 export default class QuickActions implements CodeActionProvider {
   async provideCodeActions(
@@ -59,9 +60,10 @@ export default class QuickActions implements CodeActionProvider {
         if (!versionRange.contains(range)) continue;
       }
 
-      // It's up to date
+      // Check if an update is required
+      const maxSatisfying = checkVersion(dependency.value, fetchedDep.versions)[1];
       const latestVersion = fetchedDep.versions[0];
-      if (dependency.value === latestVersion) continue;
+      if ((maxSatisfying ?? dependency.value) === latestVersion) continue;
 
       edit.replace(
         document.uri,


### PR DESCRIPTION
If the user provides a crate's version as `?`, upon saving the file it will replace the `?` with the latest version of the crate.

Cargo.toml files will now also show Quick Actions which can allow the user to individually update dependencies or even select a range of dependencies to update.

[Video demonstration](https://i.venner.io/AOG4s8LGrY.mp4)