### PR TITLE
Fix Issue #147

### DIFF
--- a/src/semver/compareVersions.ts
+++ b/src/semver/compareVersions.ts
@@ -38,8 +38,8 @@ function compareVersions(v1: string, v2: string) {
   var sp2 = s2[s2.length - 1];
 
   if (sp1 && sp2) {
-    const p1 = sp1.split('.');
-    const p2 = sp2.split('.');
+    const p1 = sp1.split('.').map((str) => /^\d+$/.test(str) ? parseInt(str, 10) : str);
+    const p2 = sp2.split('.').map((str) => /^\d+$/.test(str) ? parseInt(str, 10) : str);
     const maxLimit = Math.max(p1.length, p2.length);
     for (let i = 0; i < maxLimit; i++) {
       if (p1[i] === undefined || typeof p2[i] === 'string' && typeof p1[i] === 'number') return -1;


### PR DESCRIPTION
This correctly parses patch versions.

It seems you relied on p1 and p2 containing integers in [lines
45-49](https://github.com/serayuzgur/crates/blob/c0b97de0bf3419495fa87f1f300b456e95e70c77/src/semver/compareVersions.ts#L45),
but these variables contained all strings and no integers.

This commit parses for all-numeric integers in the semver patch so that
the comparison is valid.