### PR TITLE
Enabled and fixed features autocompletion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
 } from "vscode";
 import tomlListener from "./core/listener";
 import TomlCommands from "./toml/commands";
-import { VersionCompletions } from "./providers/autoCompletion";
+import { FeaturesCompletions, VersionCompletions } from "./providers/autoCompletion";
 
 export function activate(context: ExtensionContext) {
   const documentSelector: DocumentSelector = { language: "toml", pattern: "**/[Cc]argo.toml" };
@@ -46,12 +46,13 @@ export function activate(context: ExtensionContext) {
     //   new QuickActions(),
     //   { providedCodeActionKinds: [CodeActionKind.QuickFix] }
     // ),
-    // TODO: Register our features auto completions provider
-    // languages.registerCompletionItemProvider(
-    //   documentSelector,
-    //   new FeaturesCompletions(),
-    //   "'", '"'
-    // ),
+
+    // Register our features completion provider
+    languages.registerCompletionItemProvider(
+      documentSelector,
+      new FeaturesCompletions(),
+      "'", '"'
+    ),
   );
 
   tomlListener(window.activeTextEditor);

--- a/src/toml/parser.ts
+++ b/src/toml/parser.ts
@@ -2,7 +2,6 @@ import { TextDocument } from "vscode";
 import Item from "../core/Item";
 
 export const RE_VERSION = /^[ \t]*(?<!#)(\S+?)([ \t]*=[ \t]*)(?:({.*?version[ \t]*=[ \t]*)("|')(.*?)\4|("|')(.*?)\6)/;
-export const RE_FEATURES = /^[ \t]*(?<!#)((?:[\S]+?[ \t]*=[ \t]*.*?{.*?)?features[ \t]*=[ \t]*\[[ \t]*)(.+?)[ \t]*\]/;
 
 const RE_TABLE_HEADER = /^[ \t]*(?!#)[ \t]*\[[ \t]*(.+?)[ \t]*\][ \t]*$/;
 const RE_TABLE_HEADER_DEPENDENCY = /^(?:.+?\.)?(?:dev-)?dependencies(?:\.([^.]+?))?$/;


### PR DESCRIPTION
- Uncommented the completion provider for crate features. This was
  working for single line dependencies (under [dependencies], but not
  when a dependency is a toml table.
- On toml parsing, within filterCrates, store a dependency item's extra
  values (other than just the version). Doing this allows us to get the
  feature field later.

*Some ESLint fixes were automatically applied.