### PR TITLE
Add support for workspace.dependencies.

### DIFF
--- a/src/test/full.toml
+++ b/src/test/full.toml
@@ -26,6 +26,8 @@ futures-await = "0.1.0"
 emoji-clock = { version= "0.1.0", path = "../lib" }
 cookie_rs = { package = "cookie", version = "0.11"}
 log = "0.4"
+serde.workspace = true
+serde-json = { workspace = true, default-features = false, features = ["alloc"] }
 
 [dependencies.clap]
 version = "2.32.0"

--- a/src/test/toml/parse.test.ts
+++ b/src/test/toml/parse.test.ts
@@ -52,7 +52,7 @@ suite("Parser Tests", function() {
     {
       const item = doc.values[doc.values.length - 1];
       const section = tomlFile.substring(item.start, item.end - 1);
-      const desiredSection = tomlFile.substring(1748, 1787);
+      const desiredSection = tomlFile.substring(1853, 1891);
       assert.equal(section.length, desiredSection.length);
 
       assert.equal(section, desiredSection);
@@ -61,7 +61,7 @@ suite("Parser Tests", function() {
 
   test("Read Values", function() {
     const doc = parse(tomlFile);
-    const expected = [4, 1, 1, 1, 7, 2, 2, 1, 1, 1, 1, 5, 1, 2, 5, 1];
+    const expected = [4, 1, 1, 1, 9, 2, 2, 1, 1, 1, 1, 5, 1, 2, 5, 1];
 
     assert.equal(doc.values.length, expected.length);
     for (let i = 0; i < expected.length; i++) {

--- a/src/toml/parser.ts
+++ b/src/toml/parser.ts
@@ -67,6 +67,7 @@ export function findVersion(item: Item, level: number): Item[] {
   let dependencies: Item[] = [];
   for (let i = 0; i < item.values.length; i++) {
     let value = item.values[i];
+    if (value.key.endsWith("workspace")) continue;
     if (value.values.length > 0) {
       dependencies = dependencies.concat(findVersion(value, level + 1));
     } else if (level === 0) {
@@ -89,7 +90,7 @@ export function filterCrates(items: Item[]): Item[] {
   for (let i = 0; i < items.length; i++) {
     let value = items[i];
 
-    if (!value.key.startsWith("package.metadata")&&value.key.endsWith("dependencies")) {
+    if (!value.key.startsWith("package.metadata") && value.key.endsWith("dependencies")) {
       dependencies = dependencies.concat(findVersion(value, 0));
     } else {
       const dotIndex = value.key.lastIndexOf(".");


### PR DESCRIPTION
Rust 1.64 added workspace inheritance, which allowed dependencies in crates to be expressed with 'foo.workspace = true' syntax.

The toml parser in the crates extension would misinterpret these lines and throw an error message next to them.

With this patch, the parser skips dependencies that contain the word "workspace", only parsing these dependencies in the workspace global toml file that defines the workspace-level dependency.

This resolves #168.