### PR TITLE
Better pre-release check

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1099,7 +1099,7 @@
       "format": "esm"
     },
     "src/core/fetcher.ts": {
-      "bytes": 3490,
+      "bytes": 3590,
       "imports": [
         {
           "path": "./Item",
@@ -1471,13 +1471,13 @@
           "bytesInOutput": 1506
         },
         "src/core/fetcher.ts": {
-          "bytesInOutput": 1104
+          "bytesInOutput": 1183
         },
         "src/providers/autoCompletion.ts": {
           "bytesInOutput": 932
         }
       },
-      "bytes": 56585
+      "bytes": 56664
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crates",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "crates",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "node-cache": "5.1.2",

--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -31,6 +31,7 @@ inkwell="0.1.0-llvm8sample"
 crossbeam-utils="0.8.5"
 Inflector = "0.11.4"
 block-modes = "0.8.1" # crates: disable-check
+jpegxl-sys = "0.8.2"
 
 [dependencies.clap]
 version = "3.0.0-beta.2"

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -48,7 +48,7 @@ function transformServerResponse(versions: (name: string, indexServerURL: string
   return function (item: Item): Promise<Dependency> {
     return versions(item.key, indexServerURL).then((crate: any) => {
       const versions = crate.versions.reduce((result: any[], item: string) => {
-        const isPreRelease = !shouldListPreRels && item.indexOf("-") !== -1;
+        const isPreRelease = !shouldListPreRels && (item.indexOf("-alpha") !== -1 || item.indexOf("-beta") !== -1 || item.indexOf("-rc") !== -1 || item.indexOf("-pre") !== -1);
         if (!isPreRelease)
           result.push(item);
         return result;


### PR DESCRIPTION
Fixes #195

According to semver.org : 
```text
<valid semver> ::= <version core>
                 | <version core> "-" <pre-release>
                 | <version core> "+" <build>
                 | <version core> "-" <pre-release> "+" <build>
```

So these are "pre-release" : 
- 0.8.7-alpha.1
- 0.8.7-beta
- 0.8.7-rc.3
- 0.8.7-pre
- 0.8.7-beta+libjxl-0.8.7

But these are not (they are "build") : 
- 0.8.7+libjxl-0.8.7
- 0.8.8+libjxl-0.8.8-beta

However in this PR `0.8.8+libjxl-0.8.8-beta` **will** be treated as a "pre-release". Note that developers should not use this, they should use `0.8.8-beta+libjxl-0.8.8` instead according to semver, so I took the liberty to treat them as pre-release (and also to avoid having to parse the version 😇)