### PR TITLE
Support multiple registries (#213)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,13 @@
           "description": "URL of the index server. Default value goes to official sparse index. Alternative values would be onpremise index servers (e.g. https://api.crates-vsc.space).",
           "default": "https://index.crates.io"
         },
+        "crates.otherIndexServerURLs": {
+          "type": "array",
+          "items": "string",
+          "scope": "resource",
+          "description": "URL of other index servers.",
+          "default": []
+        },
         "crates.errorDecorator": {
           "type": "string",
           "scope": "resource",

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -14,12 +14,31 @@ import { CompletionItem, CompletionItemKind, CompletionList, workspace, window }
 import { sortText } from "../providers/autoCompletion";
 import { CrateMetadatas } from "../api/crateMetadatas";
 
-export async function fetchCrateVersions(dependencies: Item[]): Promise<[Promise<Dependency[]>, Map<string, Dependency[]>]> {
+export async function fetchCrateVersions(dependencies: Item[]): Promise<[Dependency[], Map<string, Dependency[]>]> {
   // load config
   const config = workspace.getConfiguration("");
   const shouldListPreRels = !!config.get("crates.listPreReleases");
-  var indexServerURL = config.get<string>("crates.indexServerURL") ?? sparseIndexServerURL;
+  const indexServerURL = config.get<string>("crates.indexServerURL") ?? sparseIndexServerURL;
+  const otherIndexServerURLs = config.get<string[]>("crates.otherIndexServerURLs") ?? [];
+  const allServerUrls = [indexServerURL, ...otherIndexServerURLs];
 
+  let responsesMap: Map<string, Dependency[]> = new Map();
+  const responses = await Promise.all(allServerUrls.map(url => fetchCrateVersionsFromIndex(dependencies, shouldListPreRels, url)));
+
+  let resolvedDeps: Dependency[] = responses[0]; // start with the dependencies from the first server (probably crates.io)
+  for (let server = 1; server < responses.length; server++) {
+    // if there are other servers, accumulate by replacing dependencies that still are errors
+    for (let d = 0; d < resolvedDeps.length; d++) {
+      if (resolvedDeps[d].error) {
+        // this dependency failed so far, replace by the last response
+        resolvedDeps[d] = responses[server][d];
+      }
+    }
+  }
+  return [resolvedDeps, responsesMap];
+}
+
+async function fetchCrateVersionsFromIndex(dependencies: Item[], shouldListPreRels: boolean, indexServerURL: string): Promise<Dependency[]> {
   var versions;
   try {
     if (await isSparseCompatible(indexServerURL)) {
@@ -38,9 +57,9 @@ export async function fetchCrateVersions(dependencies: Item[]): Promise<[Promise
   StatusBar.setText("Loading", "👀 Fetching " + indexServerURL.replace(/^https?:\/\//, ''));
 
   let transformer = transformServerResponse(versions, shouldListPreRels, indexServerURL);
-  let responsesMap: Map<string, Dependency[]> = new Map();
+  
   const responses = dependencies.map(transformer);
-  return [Promise.all(responses), responsesMap];
+  return Promise.all(responses);
 }
 
 

--- a/src/core/listener.ts
+++ b/src/core/listener.ts
@@ -54,7 +54,7 @@ export async function parseAndDecorate(
     dependencies = parseToml(text);
     if (fetchDeps || !fetchedDeps || !fetchedDepsMap) {
       const data = await fetchCrateVersions(dependencies);
-      fetchedDeps = await data[0];
+      fetchedDeps = data[0];
       fetchedDepsMap = data[1];
     }
 


### PR DESCRIPTION
Hi,
This is an attempt to support multiple registries. This change adds a new configuration for the specification of the additional registries, so that it is backward compatible with existing configurations.
The implementation is simply to attempt to get the data from all registries and merge them by keeping the first successful response. It is a bit brutal but it works and is a minimal change.
I tested this on my end, works like a charm with a private registry in addition to crates.io.