### PR TITLE
J32587/add colors to decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to the "crates" extension will be documented in this file.
 
-## 0.6.4
-
-- Added color options for decoration options
-
 ## 0.6.3
 
 - sparse index yanked fixed. [BarbossHack](https://github.com/BarbossHack)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "crates" extension will be documented in this file.
 
+## 0.6.4
+
+- Added color options for decoration options
+
 ## 0.6.3
 
 - sparse index yanked fixed. [BarbossHack](https://github.com/BarbossHack)

--- a/meta.json
+++ b/meta.json
@@ -937,7 +937,7 @@
       "format": "esm"
     },
     "src/ui/decoration.ts": {
-      "bytes": 4230,
+      "bytes": 4516,
       "imports": [
         {
           "path": "vscode",
@@ -963,12 +963,17 @@
           "path": "node_modules/semver/index.js",
           "kind": "import-statement",
           "original": "semver"
+        },
+        {
+          "path": "../core/DecorationText",
+          "kind": "import-statement",
+          "external": true
         }
       ],
       "format": "esm"
     },
     "src/ui/decorator.ts": {
-      "bytes": 2209,
+      "bytes": 3117,
       "imports": [
         {
           "path": "vscode",
@@ -982,6 +987,11 @@
         },
         {
           "path": "../core/Dependency",
+          "kind": "import-statement",
+          "external": true
+        },
+        {
+          "path": "../core/DecorationText",
           "kind": "import-statement",
           "external": true
         },
@@ -1223,6 +1233,12 @@
     }
   },
   "outputs": {
+    "out/main.js.map": {
+      "imports": [],
+      "exports": [],
+      "inputs": {},
+      "bytes": 251756
+    },
     "out/main.js": {
       "imports": [
         {
@@ -1285,199 +1301,199 @@
       "entryPoint": "src/extension.ts",
       "inputs": {
         "node_modules/semver/internal/constants.js": {
-          "bytesInOutput": 352
+          "bytesInOutput": 755
         },
         "node_modules/semver/internal/debug.js": {
-          "bytesInOutput": 192
+          "bytesInOutput": 328
         },
         "node_modules/semver/internal/re.js": {
-          "bytesInOutput": 3204
+          "bytesInOutput": 4836
         },
         "node_modules/semver/internal/parse-options.js": {
-          "bytesInOutput": 124
+          "bytesInOutput": 448
         },
         "node_modules/semver/internal/identifiers.js": {
-          "bytesInOutput": 216
-        },
-        "node_modules/semver/classes/semver.js": {
-          "bytesInOutput": 3836
-        },
-        "node_modules/semver/functions/parse.js": {
-          "bytesInOutput": 149
-        },
-        "node_modules/semver/functions/valid.js": {
-          "bytesInOutput": 96
-        },
-        "node_modules/semver/functions/clean.js": {
-          "bytesInOutput": 124
-        },
-        "node_modules/semver/functions/inc.js": {
-          "bytesInOutput": 190
-        },
-        "node_modules/semver/functions/diff.js": {
-          "bytesInOutput": 403
-        },
-        "node_modules/semver/functions/major.js": {
-          "bytesInOutput": 74
-        },
-        "node_modules/semver/functions/minor.js": {
-          "bytesInOutput": 74
-        },
-        "node_modules/semver/functions/patch.js": {
-          "bytesInOutput": 74
-        },
-        "node_modules/semver/functions/prerelease.js": {
-          "bytesInOutput": 120
-        },
-        "node_modules/semver/functions/compare.js": {
-          "bytesInOutput": 90
-        },
-        "node_modules/semver/functions/rcompare.js": {
-          "bytesInOutput": 68
-        },
-        "node_modules/semver/functions/compare-loose.js": {
-          "bytesInOutput": 67
-        },
-        "node_modules/semver/functions/compare-build.js": {
-          "bytesInOutput": 131
-        },
-        "node_modules/semver/functions/sort.js": {
-          "bytesInOutput": 82
-        },
-        "node_modules/semver/functions/rsort.js": {
-          "bytesInOutput": 82
-        },
-        "node_modules/semver/functions/gt.js": {
-          "bytesInOutput": 70
-        },
-        "node_modules/semver/functions/lt.js": {
-          "bytesInOutput": 70
-        },
-        "node_modules/semver/functions/eq.js": {
-          "bytesInOutput": 72
-        },
-        "node_modules/semver/functions/neq.js": {
-          "bytesInOutput": 72
-        },
-        "node_modules/semver/functions/gte.js": {
-          "bytesInOutput": 71
-        },
-        "node_modules/semver/functions/lte.js": {
-          "bytesInOutput": 71
-        },
-        "node_modules/semver/functions/cmp.js": {
-          "bytesInOutput": 519
-        },
-        "node_modules/semver/functions/coerce.js": {
-          "bytesInOutput": 528
-        },
-        "node_modules/yallist/iterator.js": {
-          "bytesInOutput": 145
-        },
-        "node_modules/yallist/yallist.js": {
-          "bytesInOutput": 4648
-        },
-        "node_modules/lru-cache/index.js": {
-          "bytesInOutput": 3549
-        },
-        "node_modules/semver/classes/range.js": {
-          "bytesInOutput": 5028
-        },
-        "node_modules/semver/classes/comparator.js": {
-          "bytesInOutput": 1767
-        },
-        "node_modules/semver/functions/satisfies.js": {
-          "bytesInOutput": 110
-        },
-        "node_modules/semver/ranges/to-comparators.js": {
-          "bytesInOutput": 126
-        },
-        "node_modules/semver/ranges/max-satisfying.js": {
-          "bytesInOutput": 209
-        },
-        "node_modules/semver/ranges/min-satisfying.js": {
-          "bytesInOutput": 208
-        },
-        "node_modules/semver/ranges/min-version.js": {
-          "bytesInOutput": 552
-        },
-        "node_modules/semver/ranges/valid.js": {
-          "bytesInOutput": 111
-        },
-        "node_modules/semver/ranges/outside.js": {
-          "bytesInOutput": 681
-        },
-        "node_modules/semver/ranges/gtr.js": {
-          "bytesInOutput": 73
-        },
-        "node_modules/semver/ranges/ltr.js": {
-          "bytesInOutput": 73
-        },
-        "node_modules/semver/ranges/intersects.js": {
-          "bytesInOutput": 106
-        },
-        "node_modules/semver/ranges/simplify.js": {
-          "bytesInOutput": 430
-        },
-        "node_modules/semver/ranges/subset.js": {
-          "bytesInOutput": 2146
-        },
-        "node_modules/semver/index.js": {
-          "bytesInOutput": 954
-        },
-        "node_modules/clone/clone.js": {
-          "bytesInOutput": 2426
-        },
-        "node_modules/node-cache/lib/node_cache.js": {
-          "bytesInOutput": 6492
-        },
-        "node_modules/node-cache/index.js": {
-          "bytesInOutput": 86
-        },
-        "src/extension.ts": {
-          "bytesInOutput": 590
-        },
-        "src/core/listener.ts": {
-          "bytesInOutput": 855
-        },
-        "src/core/Item.ts": {
-          "bytesInOutput": 190
-        },
-        "src/toml/parser.ts": {
-          "bytesInOutput": 3680
-        },
-        "src/ui/status-bar.ts": {
-          "bytesInOutput": 597
-        },
-        "src/toml/commands.ts": {
-          "bytesInOutput": 987
-        },
-        "src/ui/decorator.ts": {
-          "bytesInOutput": 857
-        },
-        "src/ui/decoration.ts": {
-          "bytesInOutput": 1570
-        },
-        "src/semver/semverUtils.ts": {
-          "bytesInOutput": 156
-        },
-        "src/api/sparse-index-server.ts": {
-          "bytesInOutput": 1189
-        },
-        "src/api/crates-index-server.ts": {
           "bytesInOutput": 564
         },
+        "node_modules/semver/classes/semver.js": {
+          "bytesInOutput": 8323
+        },
+        "node_modules/semver/functions/parse.js": {
+          "bytesInOutput": 474
+        },
+        "node_modules/semver/functions/valid.js": {
+          "bytesInOutput": 291
+        },
+        "node_modules/semver/functions/clean.js": {
+          "bytesInOutput": 320
+        },
+        "node_modules/semver/functions/inc.js": {
+          "bytesInOutput": 618
+        },
+        "node_modules/semver/functions/diff.js": {
+          "bytesInOutput": 1249
+        },
+        "node_modules/semver/functions/major.js": {
+          "bytesInOutput": 226
+        },
+        "node_modules/semver/functions/minor.js": {
+          "bytesInOutput": 226
+        },
+        "node_modules/semver/functions/patch.js": {
+          "bytesInOutput": 226
+        },
+        "node_modules/semver/functions/prerelease.js": {
+          "bytesInOutput": 357
+        },
+        "node_modules/semver/functions/compare.js": {
+          "bytesInOutput": 261
+        },
+        "node_modules/semver/functions/rcompare.js": {
+          "bytesInOutput": 237
+        },
+        "node_modules/semver/functions/compare-loose.js": {
+          "bytesInOutput": 247
+        },
+        "node_modules/semver/functions/compare-build.js": {
+          "bytesInOutput": 406
+        },
+        "node_modules/semver/functions/sort.js": {
+          "bytesInOutput": 258
+        },
+        "node_modules/semver/functions/rsort.js": {
+          "bytesInOutput": 262
+        },
+        "node_modules/semver/functions/gt.js": {
+          "bytesInOutput": 217
+        },
+        "node_modules/semver/functions/lt.js": {
+          "bytesInOutput": 217
+        },
+        "node_modules/semver/functions/eq.js": {
+          "bytesInOutput": 219
+        },
+        "node_modules/semver/functions/neq.js": {
+          "bytesInOutput": 223
+        },
+        "node_modules/semver/functions/gte.js": {
+          "bytesInOutput": 222
+        },
+        "node_modules/semver/functions/lte.js": {
+          "bytesInOutput": 222
+        },
+        "node_modules/semver/functions/cmp.js": {
+          "bytesInOutput": 1200
+        },
+        "node_modules/semver/functions/coerce.js": {
+          "bytesInOutput": 1209
+        },
+        "node_modules/yallist/iterator.js": {
+          "bytesInOutput": 344
+        },
+        "node_modules/yallist/yallist.js": {
+          "bytesInOutput": 9890
+        },
+        "node_modules/lru-cache/index.js": {
+          "bytesInOutput": 8326
+        },
+        "node_modules/semver/classes/range.js": {
+          "bytesInOutput": 12144
+        },
+        "node_modules/semver/classes/comparator.js": {
+          "bytesInOutput": 3703
+        },
+        "node_modules/semver/functions/satisfies.js": {
+          "bytesInOutput": 380
+        },
+        "node_modules/semver/ranges/to-comparators.js": {
+          "bytesInOutput": 334
+        },
+        "node_modules/semver/ranges/max-satisfying.js": {
+          "bytesInOutput": 704
+        },
+        "node_modules/semver/ranges/min-satisfying.js": {
+          "bytesInOutput": 701
+        },
+        "node_modules/semver/ranges/min-version.js": {
+          "bytesInOutput": 1616
+        },
+        "node_modules/semver/ranges/valid.js": {
+          "bytesInOutput": 340
+        },
+        "node_modules/semver/ranges/outside.js": {
+          "bytesInOutput": 2042
+        },
+        "node_modules/semver/ranges/gtr.js": {
+          "bytesInOutput": 243
+        },
+        "node_modules/semver/ranges/ltr.js": {
+          "bytesInOutput": 243
+        },
+        "node_modules/semver/ranges/intersects.js": {
+          "bytesInOutput": 343
+        },
+        "node_modules/semver/ranges/simplify.js": {
+          "bytesInOutput": 1403
+        },
+        "node_modules/semver/ranges/subset.js": {
+          "bytesInOutput": 5449
+        },
+        "node_modules/semver/index.js": {
+          "bytesInOutput": 2536
+        },
+        "node_modules/clone/clone.js": {
+          "bytesInOutput": 6761
+        },
+        "node_modules/node-cache/lib/node_cache.js": {
+          "bytesInOutput": 16444
+        },
+        "node_modules/node-cache/index.js": {
+          "bytesInOutput": 255
+        },
+        "src/extension.ts": {
+          "bytesInOutput": 1743
+        },
+        "src/core/listener.ts": {
+          "bytesInOutput": 1863
+        },
+        "src/core/Item.ts": {
+          "bytesInOutput": 321
+        },
+        "src/toml/parser.ts": {
+          "bytesInOutput": 8140
+        },
+        "src/ui/status-bar.ts": {
+          "bytesInOutput": 968
+        },
+        "src/toml/commands.ts": {
+          "bytesInOutput": 1802
+        },
+        "src/ui/decorator.ts": {
+          "bytesInOutput": 2392
+        },
+        "src/ui/decoration.ts": {
+          "bytesInOutput": 3461
+        },
+        "src/semver/semverUtils.ts": {
+          "bytesInOutput": 337
+        },
+        "src/api/sparse-index-server.ts": {
+          "bytesInOutput": 2592
+        },
+        "src/api/crates-index-server.ts": {
+          "bytesInOutput": 1196
+        },
         "src/semver/compareVersions.ts": {
-          "bytesInOutput": 1506
+          "bytesInOutput": 2498
         },
         "src/core/fetcher.ts": {
-          "bytesInOutput": 1183
+          "bytesInOutput": 2754
         },
         "src/providers/autoCompletion.ts": {
-          "bytesInOutput": 932
+          "bytesInOutput": 2149
         }
       },
-      "bytes": 56689
+      "bytes": 135396
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crates",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "crates",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "node-cache": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -76,17 +76,123 @@
           "default": "❗️❗️❗️",
           "description": "The text to show when a dependency has errors."
         },
+        "crates.errorDecoratorCss": {
+          "type": "object",
+          "default": null,
+          "properties": {
+            "after": {
+              "type": "object",
+              "default": null,
+              "scope": "resource",
+              "description": "Text styling",
+              "properties": {
+                "color": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "#ffffffff",
+                  "format": "color",
+                  "description": "css color"
+                },
+                "border": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "2px ",
+                  "description": "css border"
+                },
+                "backgroundColor": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "#00000000",
+                  "format": "color",
+                  "description": "css background-color"
+                }
+              }
+            },
+            "description": "Text that appears at the end of the line"
+          },
+          "description": "CSS to be applied to a line when there is a dependency error"
+        },
         "crates.incompatibleDecorator": {
           "type": "string",
           "scope": "resource",
           "default": "❌ ${version}",
           "description": "The text template to show when a dependency is not semver compatible. ${version} will be replaced by the latest version info."
         },
+        "crates.incompatibleDecoratorCss": {
+          "type": "object",
+          "default": null,
+          "properties": {
+            "after": {
+              "type": "object",
+              "default": null,
+              "scope": "resource",
+              "description": "Text styling",
+              "properties": {
+                "color": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "#ffffffff",
+                  "format": "color",
+                  "description": "css color"
+                },
+                "border": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "",
+                  "description": "css border"
+                },
+                "backgroundColor": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "#00000000",
+                  "format": "color",
+                  "description": "css background-color"
+                }
+              }
+            }
+          },
+          "description": "CSS to be applied to an incompatible line"
+        },
         "crates.compatibleDecorator": {
           "type": "string",
           "scope": "resource",
           "default": "✅",
           "description": "The text template to show when a dependency is semver compatible. ${version} will be replaced by the latest version info."
+        },
+        "crates.compatibleDecoratorCss": {
+          "type": "object",
+          "default": null,
+          "properties": {
+            "after": {
+              "type": "object",
+              "default": null,
+              "scope": "resource",
+              "description": "Text styling",
+              "properties": {
+                "color": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "#ffffffff",
+                  "format": "color",
+                  "description": "css color"
+                },
+                "border": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": null,
+                  "description": "css border"
+                },
+                "backgroundColor": {
+                  "type": "string",
+                  "scope": "resource",
+                  "default": "#00000000",
+                  "format": "color",
+                  "description": "css background-color"
+                }
+              }
+            }
+          },
+          "description": "CSS to be applied to a compatible line"
         }
       }
     }
@@ -99,6 +205,7 @@
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
     "test-compile": "tsc -p ./"
   },
+  "types": "vscode",
   "devDependencies": {
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",

--- a/src/core/DecorationText.ts
+++ b/src/core/DecorationText.ts
@@ -1,0 +1,11 @@
+
+import { DecorationInstanceRenderOptions } from "vscode"
+
+/**
+ * DecorationText is a data structure that binds the decoration text to its configured css
+ */
+export default interface DecorationPreferences {
+    compatibleDecoratorCss: DecorationInstanceRenderOptions,
+    incompatibleDecoratorCss: DecorationInstanceRenderOptions,
+    errorDecoratorCss: DecorationInstanceRenderOptions
+}

--- a/src/ui/decorator.ts
+++ b/src/ui/decorator.ts
@@ -1,10 +1,10 @@
-import { TextEditor, TextEditorDecorationType, workspace, DecorationOptions } from "vscode";
+import { TextEditor, TextEditorDecorationType, workspace, DecorationOptions, DecorationInstanceRenderOptions } from "vscode";
 import { StatusBar } from "./status-bar";
 import Dependency from "../core/Dependency";
+import DecorationPreferences from "../core/DecorationText";
 import decoration, { latestVersion } from "./decoration";
 
 export let decorationHandle: TextEditorDecorationType;
-
 
 /**
  *
@@ -29,13 +29,11 @@ export default function decorate(editor: TextEditor, dependencies: Array<Depende
   for (let i = filtered.length - 1; i > -1; i--) {
     const dependency: Dependency = filtered[i];
     try {
-      const decor = decoration(
+      let decor = decoration(
         editor,
         dependency.item,
         dependency.versions || [],
-        pref.compatibleDecorator,
-        pref.incompatibleDecorator,
-        pref.errorDecorator,
+        pref,
         dependency.error,
       );
       if (decor) {
@@ -63,14 +61,30 @@ ${errors.join('\n')}`);
 
 function loadPref() {
   const config = workspace.getConfiguration("");
-  const compatibleDecorator = config.get<string>("crates.compatibleDecorator") ?? "";
-  const incompatibleDecorator = config.get<string>("crates.incompatibleDecorator") ?? "";
+  const compatibleDecoratorText = config.get<string>("crates.compatibleDecorator") ?? "";
+  let compatibleDecoratorCss = config.get<DecorationInstanceRenderOptions>("crates.compatibleDecoratorCss") ?? {};
   const errorText = config.get<string>("crates.errorDecorator");
-  const errorDecorator = errorText ? errorText + "" : "";
+  let errorDecoratorCss = config.get<DecorationInstanceRenderOptions>("crates.errorDecoratorCss") ?? {};
+  const incompatibleDecoratorText = config.get<string>("crates.incompatibleDecorator") ?? "";
+  let incompatibleDecoratorCss = config.get<DecorationInstanceRenderOptions>("crates.incompatibleDecoratorCss") ?? {};
+  const errorDecoratorText = errorText ? errorText + "" : "";
+  if(compatibleDecoratorCss.after == undefined) {
+    compatibleDecoratorCss.after = {}
+  }
+  if(incompatibleDecoratorCss.after == undefined) {
+    incompatibleDecoratorCss.after = {}
+  }
+  if(errorDecoratorCss.after == undefined) {
+    errorDecoratorCss.after = {}
+  }
+  compatibleDecoratorCss.after.contentText = compatibleDecoratorText;
+  incompatibleDecoratorCss.after.contentText = incompatibleDecoratorText;
+  errorDecoratorCss.after.contentText = errorDecoratorText;
+
   return {
-    compatibleDecorator,
-    incompatibleDecorator,
-    errorDecorator,
+    compatibleDecoratorCss: compatibleDecoratorCss,
+    incompatibleDecoratorCss: incompatibleDecoratorCss,
+    errorDecoratorCss: errorDecoratorCss
   };
 }
 


### PR DESCRIPTION
# Purpose
This pull request allows the CSS of lines with the error, compatible, and incompatible decoration to be modified.

# Example (using nerd font)
![example_config](https://github.com/serayuzgur/crates/assets/118198996/8d74ed8f-1904-4efc-b370-ff4731e90dfa)
![example_toml](https://github.com/serayuzgur/crates/assets/118198996/717105ce-13fe-4397-88f1-4c554a048619)
