### PR TITLE
detect Cargo.toml in subfolders

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "activationEvents": [
     "onLanguage:toml",
-    "workspaceContains:Cargo.toml"
+    "workspaceContains:*/Cargo.toml"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
If you have a repository where the rust project lives in a subfolder (say, a monorepo hosting several services), the crates extension won't activate unless you add a blank `Cargo.toml` to the repository root. This PR addresses that - it now uses the same `activationEvent` check for `Cargo.toml` that the official `rust-analyzer` extension uses.