### PR TITLE
Ignore crates that have an alternate registry

### DIFF
--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -33,6 +33,11 @@ Inflector = "0.11.4"
 block-modes = "0.8.1" # crates: disable-check
 jpegxl-sys = "0.8.2"
 tracing = "=0.1.37"
+external = { version = "0.0.1", registry = "ext_reg" }
+
+[dependencies.external2]
+registry = "ext_reg"
+version = "0.0.2"
 
 [dependencies.clap]
 version = "3.0.0-beta.2"

--- a/src/core/Item.ts
+++ b/src/core/Item.ts
@@ -5,6 +5,7 @@ export default class Item {
   key: string = "";
   values: Array<any> = [];
   value: string | undefined = "";
+  registry?: string;
   start: number = -1;
   end: number = -1;
   constructor(item?: Item) {
@@ -12,6 +13,7 @@ export default class Item {
       this.key = item.key;
       this.values = item.values;
       this.value = item.value;
+      this.registry = item.registry;
       this.start = item.start;
       this.end = item.end;
     }

--- a/src/core/listener.ts
+++ b/src/core/listener.ts
@@ -15,8 +15,11 @@ function parseToml(text: string): Item[] {
   console.log("Parsing...");
   const toml = parse(text);
   const tomlDependencies = filterCrates(toml.values);
+  // Atm, ignore crates that have an alternate registry, as we do not support them yet,
+  // but this may change in the future.
+  const tomlDependenciesWoReg = tomlDependencies.filter((crate) => crate.registry === undefined);
   console.log("Parsed");
-  return tomlDependencies;
+  return tomlDependenciesWoReg;
 }
 
 var dependencies: Item[];

--- a/src/toml/parser.ts
+++ b/src/toml/parser.ts
@@ -79,6 +79,7 @@ function findVersion(item: Item): Item[] {
 function findVersionTable(table: Item): Item | null {
   let item = null
   let itemName = null;
+  let itemRegistry = undefined;
   for (const field of table.values) {
     if (field.key === "workspace") return null;
     if (field.key === "version") {
@@ -86,8 +87,10 @@ function findVersionTable(table: Item): Item | null {
       item.key = table.key;
     }
     if (field.key === "package") itemName = field.value;
+    if (field.key === "registry") itemRegistry = field.value;
   }
   if (item && itemName) item.key = itemName;
+  if (item && itemRegistry !== undefined) item.registry = itemRegistry;
   return item;
 }
 


### PR DESCRIPTION
This is the first (small) step to support alternate registries. 

What this PR does: 
- save the `alternate registry` (if any) in the `Item` struct
- ignore crates that are on an `alternate registry`

Why ignoring crates that have an alternate registry ? Actually (v0.6.6), we check crates versions on `index.crates.io`, even for crates that have specify an alternate registry, although it should **NOT** (as described here https://github.com/serayuzgur/crates/pull/217#issuecomment-1975172827). And as we do not support alternate registries _yet_, we MUST ignore them.

I think we can release a new version of `Crates` with this PR, as we don't know yet when the support for alternate registries will be added (but I think I will work on it) :+1: 